### PR TITLE
re-add augmented-ui, disable postcss-calc until parsing error is fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3392,7 +3392,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3410,11 +3411,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3427,15 +3430,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3538,7 +3544,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3548,6 +3555,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3560,17 +3568,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3587,6 +3598,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3659,7 +3671,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3669,6 +3682,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3744,7 +3758,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3774,6 +3789,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3791,6 +3807,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3829,11 +3846,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -7815,7 +7834,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7833,11 +7853,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7850,15 +7872,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7961,7 +7986,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7971,6 +7997,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7983,17 +8010,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8010,6 +8040,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8082,7 +8113,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8092,6 +8124,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8167,7 +8200,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8197,6 +8231,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8214,6 +8249,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8252,11 +8288,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,14 @@
   "eslintConfig": {
     "extends": "react-app"
   },
+  "cssnano": {
+    "preset": [
+      "default",
+      {
+        "calc": false
+      }
+    ]
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-// import './augmented.css';
+import './augmented.css';
 import './index.scss';
 import QuoteMachine from './QuoteMachine';
 import 'victormono';

--- a/src/index.scss
+++ b/src/index.scss
@@ -24,19 +24,19 @@ body {
   display: inline-block;
   margin: 10px;
   min-width: 400px;
-  // --aug-border: 5px;
-  // --aug-inset: 5px;
-  padding: 50px 50px 20px;; /* mind the gap */
+  --aug-border: 5px;
+  --aug-inset: 5px;
+  padding: 50px 50px 20px;
   text-align: center;
   background: #7e9dcd;
   border-radius: 7px;
-  // --aug-inset-bg: #7e9dcd;
-  // --aug-bl: 25px;
-  // --aug-r-width: 20px;
-  // --aug-r-height: 25%;
-  // --aug-t-width: 20px;
-  // --aug-t-height: 25%;
-  // --aug-border-bg: linear-gradient(to bottom right, rebeccapurple, dodgerblue, indigo);
+  --aug-inset-bg: #7e9dcd;
+  --aug-bl: 25px;
+  --aug-r-width: 20px;
+  --aug-r-height: 25%;
+  --aug-t-width: 20px;
+  --aug-t-height: 25%;
+  --aug-border-bg: linear-gradient(to bottom right, rebeccapurple, dodgerblue, indigo);
 }
 
 #title {
@@ -76,7 +76,7 @@ body {
 div.btn {
   display: inline-block;
   margin: 10px;
-  padding: 12px 24px; /* mind the gap */
+  padding: 12px 24px;
   text-align: center;
   font-size: 21px;
   color: #1a254a;
@@ -84,16 +84,16 @@ div.btn {
 
   border: navy 1px solid;
   border-radius: 5px;
-  // --aug-border: 2px;
-  // --aug-inset: 5px;
-  // --aug-border-bg: linear-gradient(to bottom right, rgb(33, 33, 218), dodgerblue);
-  // --aug-inset-bg: rgba(255,255,255,.2);
+  --aug-border: 2px;
+  --aug-inset: 5px;
+  --aug-border-bg: linear-gradient(to bottom right, rgb(33, 33, 218), dodgerblue);
+  --aug-inset-bg: rgba(255,255,255,.2);
   background: rgba(255,255,255,.5);
   &:hover,
   &:active {
     color: navy;
     background: rgba(255,255,255,.4);
-    // --aug-inset-bg: rgba(255,255,255,.3);
+    --aug-inset-bg: rgba(255,255,255,.3);
   }
 
   a {
@@ -103,7 +103,7 @@ div.btn {
     &:hover,
     &:active {
       color: navy;
-      // --aug-inset-bg: rgba(255,255,255,.3);
+      --aug-inset-bg: rgba(255,255,255,.3);
     }
   }
 }


### PR DESCRIPTION
Hey! I like the project idea and it looks great with augmented-ui:
![image](https://user-images.githubusercontent.com/7545075/65195105-67c2e280-da43-11e9-9be4-b48020d82070.png)

This fixes that build issue you ran into. Postcss-calc has an error in its parser that's being worked on. You can see details here:
https://github.com/postcss/postcss-calc/issues/77

The "fix" is to disabled postcss's calc parsing until bug is fixed, per this comment here:
https://github.com/postcss/postcss-calc/issues/77#issuecomment-491354918

(the only real change is adding this config to your package.json, the rest was un-commenting the augmented-ui styles and import you left in!)

Hope this helps! Thank you for checking out augmented-ui even if you decide against using it for now!
//James